### PR TITLE
fix bower metadata

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "devicons",
   "description": "Devicons - An icon font made for developers",
-  "version": "1.3",
+  "version": "1.3.0",
   "keywords": [
     "icons",
     "devicons",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "devicons",
   "description": "An iconic font made for developers",
-  "version": "1.3.0",
+  "version": "v1.3.0",
   "keywords": ["font", "icons", "devicons", "glyphs" ],
   "homepage": "http://fontawesome.io/",
   "bugs": {


### PR DESCRIPTION
package.json needs the exact git tag name as version number to install successfully. I've also appended .0 to the version number in bower.json for the sake of keeping it unified.

You will need to update your v1.3.0 tag to the fixed commit for this to fix the issue.

Thanks for all your work :+1: 
