### PR TITLE
bump version numbers for 1p3p1 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 [v1.1](#v1.1)
 [v1.2](#v1.2)
-[v1.2](#v1.3)
+[v1.3](#v1.3)
+[v1.3.1](#v1.3.1)
 
+## v1.3.1
+
+Change log and fixes in version 1.3.1:
+1. Minor fix to unbreak bower package manager by [@daveio](https://github.com/daveio)
 
 ## v1.3
 
@@ -15,14 +20,12 @@ Change log and fixes in version 1.3:
 3. Added Nancy icon as suggested by [@markwellis](https://github.com/markwellis).
 4. Added PostgreSQL icon as suggested by [@RoryDH](https://github.com/RoryDH).
 5. Added Jenkins icon as suggested by Daniel Serodio.
-
 6.Also added Celluloid, W3C, Redis and Web platform icons
 
 ## v1.2
 
 Change log and fixes in version 1.2:
 1. Added Gulp.js badge as suggested by [@pkozlowski-opensource](https://github.com/pkozlowski-opensource). 
-
 2. Added Cisco, and Atom IDE icons as well.
 3. Devicons is also available via NPM 
 4. Added status and issue badges in README.md

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Devicons is a full stack iconic font ready to be shipped with your next project.
 Devicons iconic font is free to use and licensed under [MIT](http://opensource.org/licenses/MIT).  
 
 
-###Devicons icon set v 1.3
+###Devicons icon set v 1.3.1
 ![Devicons](http://i.imgur.com/nTQC2my.png)
 
 
@@ -63,6 +63,7 @@ Do you have any additional request? Drop me a line or support an issue.
 
 
 ##Changelog
+- v1.3.1 Minor fixes for bower package manager
 - v1.3.0 Added 10 new icons - 111 glyphs 
 - v1.2.0 Added 3 new icons - 101 glyphs 
 - v1.1.0 Added 12 new icons - 97 glyphs 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "devicons",
   "description": "Devicons - An icon font made for developers",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "keywords": [
     "icons",
     "devicons",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "devicons",
   "description": "An iconic font made for developers",
-  "version": "v1.3.0",
+  "version": "v1.3.1",
   "keywords": ["font", "icons", "devicons", "glyphs" ],
   "homepage": "http://fontawesome.io/",
   "bugs": {


### PR DESCRIPTION
This is set up for a tag named 'v1.3.1' after which bower should work properly.

...should.

:8ball: 
