### PR TITLE
fix overriding fonts

### DIFF
--- a/css/devicons.css
+++ b/css/devicons.css
@@ -8,7 +8,7 @@
   font-weight: normal;
   font-style: normal; }
 .devicons {
-  font-family: 'devicons';
+  font-family: inherit;
   speak: none;
   font-style: normal;
   font-weight: normal;
@@ -18,6 +18,9 @@
   /* Better Font Rendering =========== */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale; }
+
+.devicons:before {
+    font-family: 'devicons'; }
 
 .devicons-git:before {
   content: "\e602"; }


### PR DESCRIPTION
Hello,

I think there is an issue when using the `devicons` class in an element also containing text. If for example i have the following:

```
<a href="http://git-scm.com" class="devicons devicons-git">Git rocks</a>
```

the "Git rocks" text `font-family` will be `devicons` which would reset any custom font inserted.

The solution would be adding the `font-family` to the `:before` pseudo-element. 

I know it's a long shot but what do you think? It gets easily hacked by adding my fix in a custom style though
