### PR TITLE
List main files explicitly to work with "grunt-wiredep"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,8 +10,11 @@
   "homepage": "http://vorillaz.github.io/devicons/",
   "license": "MIT",
   "main": [
-    "./css/*",
-    "./fonts/*"
+    "css/devicons.css",
+    "fonts/devicons.eot",
+    "fonts/devicons.svg",
+    "fonts/devicons.ttf",
+    "fonts/devicons.woff"
   ],
   "ignore": [
     "*/.*",


### PR DESCRIPTION
Tools like "wiredep" use the bower "main" property to automatically inject css/js in your index.html.

They expect files to be listed explicitly!
With the current glob notation, grunt-wiredep does not find the "devicons.css" file.
