### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Devicons iconic font is free to use and licensed under [MIT](http://opensource.o
 ## Use Devicons with a single line of code.
 Thanks to the wonderful guys of  [jsdelivr](http://www.jsdelivr.com/) you can now add Devicons into your project by adding the following code into the `<HEAD>` section of your project's HTML:
 
-`<link href='//cdn.jsdelivr.net/devicons/1.8.0/css/devicons.min.css' rel='stylesheet'>`
+`<link href='//cdn.jsdelivr.net/npm/devicons@1.8.0/css/devicons.min.css' rel='stylesheet'>`
 
 
 ## Getting Started

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "devicons",
   "description": "An iconic font made for developers",
   "version": "1.8.0",
+  "jsdelivr": "css/devicons.min.css",
   "keywords": ["font", "icons", "devicons", "glyphs" ],
   "homepage": "http://vorillaz.github.io/devicons/",
   "bugs": {


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.
I also set the default file to `css/devicons.min.css`.

You can find links for all files at https://www.jsdelivr.com/package/npm/devicons.

Feel free to ping me if you have any questions regarding this change.