### PR TITLE
Add overwrittable variable to change path to fonts directory

### DIFF
--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -1,0 +1,1 @@
+$devicons-font-path: "../fonts" !default;

--- a/css/devicons.scss
+++ b/css/devicons.scss
@@ -1,13 +1,16 @@
 /*!
  *  Devicons 1.8.0 made by Theodore Vorillas / http://vorillaz.com 
  */
+
+@import "./_variables";
+
 @font-face {
 	font-family: 'devicons';
-	src:url('../fonts/devicons.eot?xqxft6');
-	src:url('../fonts/devicons.eot?#iefixxqxft6') format('embedded-opentype'),
-		url('../fonts/devicons.woff?xqxft6') format('woff'),
-		url('../fonts/devicons.ttf?xqxft6') format('truetype'),
-		url('../fonts/devicons.svg?xqxft6#devicons') format('svg');
+	src:url('#{$devicons-font-path}/devicons.eot?xqxft6');
+	src:url('#{$devicons-font-path}/devicons.eot?#iefixxqxft6') format('embedded-opentype'),
+		url('#{$devicons-font-path}/devicons.woff?xqxft6') format('woff'),
+		url('#{$devicons-font-path}/devicons.ttf?xqxft6') format('truetype'),
+		url('#{$devicons-font-path}/devicons.svg?xqxft6#devicons') format('svg');
 	font-weight: normal;
 	font-style: normal;
 }


### PR DESCRIPTION
It is useful for build bundles with webpack or other package managers, if you want to create your own CSS bundle that will consist many css libraries, you can use file-loader

```javascript
{
  test: /\.(ttf|otf|eot|svg|woff)/,
  use: [{
    loader: 'file-loader',
    options: {
      name: '[name].[ext]',
      outputPath: 'fonts/',		// where the fonts will go
      publicPath: './fonts/'		// override the default path
    }
  }]
}
```

in your main SCSS file you need to overwrite `$devicons-file-path` variable, then build will success

### Build result **without** overwriting fonts path:
![screen shot 2018-04-21 at 17 06 57](https://user-images.githubusercontent.com/13422799/39085066-6b3a883a-4586-11e8-9746-a7100a5b3ce9.png)

### Main SCSS file with overwritten `$devicons-file-path` variable:
![screen shot 2018-04-21 at 17 02 35](https://user-images.githubusercontent.com/13422799/39085046-2d58084e-4586-11e8-8566-be8397552a08.png)

### Build result:
![screen shot 2018-04-21 at 17 06 04](https://user-images.githubusercontent.com/13422799/39085056-4dd0f838-4586-11e8-9b61-274f1a133655.png)


### Result is a sindle bundle that consist font-awesome and devicons (and my additional styles):
![screen shot 2018-04-21 at 17 09 22](https://user-images.githubusercontent.com/13422799/39085107-d4de1266-4586-11e8-8984-8ed68bf016bf.png)


 ### And it's work!
![screen shot 2018-04-21 at 17 18 21](https://user-images.githubusercontent.com/13422799/39085206-0a39c54e-4588-11e8-91f8-094d1aac7fbd.png)


![tumblr_n2wxgjmnbf1rvf139o1_500](https://user-images.githubusercontent.com/13422799/39085154-45424644-4587-11e8-94d8-92db2915b70b.gif)
