### PR TITLE
fix(seo): emit license/acquireLicensePage/copyrightNotice on icon ImageObject

### DIFF
--- a/apps/website/src/layouts/Icon.astro
+++ b/apps/website/src/layouts/Icon.astro
@@ -32,6 +32,7 @@ const {
   version,
   website,
   license,
+  brandGuidelines,
   mainColor,
   otherColors,
   badInDark,
@@ -62,7 +63,7 @@ const jsonLd = [
     { name, url: `/icons/${slug}` },
   ]),
   iconBrandSchema({ name, description, slug, website, mainColor }),
-  iconImageSchema({ name, slug, license }),
+  iconImageSchema({ name, slug, license, brandGuidelines }),
 ];
 
 const colorChips = [

--- a/apps/website/src/lib/seo.ts
+++ b/apps/website/src/lib/seo.ts
@@ -70,6 +70,7 @@ interface IconSchemaInput {
   website?: string;
   mainColor?: string;
   license?: string;
+  brandGuidelines?: string;
   site?: string;
 }
 
@@ -94,18 +95,24 @@ export const iconImageSchema = ({
   name,
   slug,
   license,
+  brandGuidelines,
   site = SITE_URL,
-}: IconSchemaInput): JsonLd => ({
-  '@context': 'https://schema.org',
-  '@type': 'ImageObject',
-  contentUrl: abs(`/devicons/icons/${slug}.svg`, site),
-  url: abs(`/icons/${slug}`, site),
-  name: `${name} logo`,
-  encodingFormat: 'image/svg+xml',
-  ...(license ? { license } : {}),
-  creditText: name,
-  creator: { '@id': abs('/#organization', site) },
-});
+}: IconSchemaInput): JsonLd => {
+  const pageUrl = abs(`/icons/${slug}`, site);
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ImageObject',
+    contentUrl: abs(`/devicons/icons/${slug}.svg`, site),
+    url: pageUrl,
+    name: `${name} logo`,
+    encodingFormat: 'image/svg+xml',
+    license: license ?? `${GITHUB_URL}/blob/main/LICENSE`,
+    acquireLicensePage: brandGuidelines ?? pageUrl,
+    copyrightNotice: `${name} logo © ${name}. SVG distributed under MIT by ${SITE_TITLE}.`,
+    creditText: name,
+    creator: { '@id': abs('/#organization', site) },
+  };
+};
 
 interface TechArticleInput {
   title: string;

--- a/apps/website/src/pages/icons/[slug]/[framework].astro
+++ b/apps/website/src/pages/icons/[slug]/[framework].astro
@@ -96,7 +96,7 @@ const { entry, framework } = Astro.props as {
   entry: CollectionEntry<'icons'>;
   framework: Framework;
 };
-const { name, description, icons: iconFiles, website, mainColor, license } =
+const { name, description, icons: iconFiles, website, mainColor, license, brandGuidelines } =
   entry.data;
 const meta = FRAMEWORK_META[framework];
 const cmp =
@@ -125,7 +125,7 @@ const jsonLd = [
     website,
     mainColor,
   }),
-  iconImageSchema({ name, slug: entry.id, license }),
+  iconImageSchema({ name, slug: entry.id, license, brandGuidelines }),
 ];
 
 const importSnippet = meta.buildImport(cmp);


### PR DESCRIPTION
Closes Search Console "non-critical" warnings on `/icons/{slug}` pages by populating the three Google-recommended `ImageObject` license fields.

- `license` → repo `LICENSE` URL (per-icon `license:` frontmatter overrides)
- `acquireLicensePage` → icon's `brandGuidelines` if set, else the icon page URL
- `copyrightNotice` → `"{Name} logo © {Name}. SVG distributed under MIT by Devicons."`

Validate one URL with the Rich Results Test after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)